### PR TITLE
SLING-9206 - Add support for executing precompiled JSP scripts

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,3 +1,7 @@
 ScriptEngine-Name:${project.name}
 ScriptEngine-Version:${project.version}
+Import-Package:     org.apache.sling.commons.compiler.*;resolution:=optional, \\
+                    org.apache.sling.commons.classloader.*;resolution:=optional, \\
+                    org.apache.sling.scripting.bundle.tracker.*;resolution:=optional, \\
+                    *
 -conditionalpackage: org.apache.el.*

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,7 +1,5 @@
 ScriptEngine-Name:${project.name}
 ScriptEngine-Version:${project.version}
-Import-Package:     org.apache.sling.commons.compiler.*;resolution:=optional, \\
-                    org.apache.sling.commons.classloader.*;resolution:=optional, \\
-                    org.apache.sling.scripting.bundle.tracker.*;resolution:=optional, \\
+Import-Package:     org.apache.sling.scripting.bundle.tracker.*;resolution:=optional, \\
                     *
 -conditionalpackage: org.apache.el.*

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.scripting.jsp</artifactId>
-    <version>2.4.3-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <name>Apache Sling Scripting JSP</name>
     <description>Support for JSP scripting</description>
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.api</artifactId>
-            <version>2.1.6</version>
+            <version>2.1.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -143,6 +143,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.scripting.bundle.tracker</artifactId>
+            <version>0.1.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/apache/sling/scripting/jsp/JspServletConfig.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/JspServletConfig.java
@@ -76,4 +76,8 @@ class JspServletConfig implements ServletConfig {
         }
         return sb.toString();
     }
+
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
 }

--- a/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
@@ -50,15 +50,18 @@ public class PrecompiledJSPRunner {
             if (bundledRenderUnit != null && bundledRenderUnit.getUnit() instanceof HttpJspBase) {
                 found = true;
                 jsp = (HttpJspBase) bundledRenderUnit.getUnit();
-                if (jsp.getServletConfig() == null) {
-                    PrecompiledServletConfig servletConfig = new PrecompiledServletConfig(jspServletConfig, bundledRenderUnit);
-                    AnnotationProcessor annotationProcessor =
-                            (AnnotationProcessor) jspServletConfig.getServletContext().getAttribute(AnnotationProcessor.class.getName());
-                    if (annotationProcessor != null) {
-                        annotationProcessor.processAnnotations(jsp);
-                        annotationProcessor.postConstruct(jsp);
+                synchronized (this) {
+                    if (jsp.getServletConfig() == null) {
+                        PrecompiledServletConfig servletConfig = new PrecompiledServletConfig(jspServletConfig, bundledRenderUnit);
+                        AnnotationProcessor annotationProcessor =
+                                (AnnotationProcessor) jspServletConfig.getServletContext()
+                                        .getAttribute(AnnotationProcessor.class.getName());
+                        if (annotationProcessor != null) {
+                            annotationProcessor.processAnnotations(jsp);
+                            annotationProcessor.postConstruct(jsp);
+                        }
+                        jsp.init(servletConfig);
                     }
-                    jsp.init(servletConfig);
                 }
                 jsp.service(bindings.getRequest(), bindings.getResponse());
 

--- a/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
@@ -50,17 +50,19 @@ public class PrecompiledJSPRunner {
             if (bundledRenderUnit != null && bundledRenderUnit.getUnit() instanceof HttpJspBase) {
                 found = true;
                 jsp = (HttpJspBase) bundledRenderUnit.getUnit();
-                synchronized (this) {
-                    if (jsp.getServletConfig() == null) {
-                        PrecompiledServletConfig servletConfig = new PrecompiledServletConfig(jspServletConfig, bundledRenderUnit);
-                        AnnotationProcessor annotationProcessor =
-                                (AnnotationProcessor) jspServletConfig.getServletContext()
-                                        .getAttribute(AnnotationProcessor.class.getName());
-                        if (annotationProcessor != null) {
-                            annotationProcessor.processAnnotations(jsp);
-                            annotationProcessor.postConstruct(jsp);
+                if (jsp.getServletConfig() == null) {
+                    synchronized (this) {
+                        if (jsp.getServletConfig() == null) {
+                            PrecompiledServletConfig servletConfig = new PrecompiledServletConfig(jspServletConfig, bundledRenderUnit);
+                            AnnotationProcessor annotationProcessor =
+                                    (AnnotationProcessor) jspServletConfig.getServletContext()
+                                            .getAttribute(AnnotationProcessor.class.getName());
+                            if (annotationProcessor != null) {
+                                annotationProcessor.processAnnotations(jsp);
+                                annotationProcessor.postConstruct(jsp);
+                            }
+                            jsp.init(servletConfig);
                         }
-                        jsp.init(servletConfig);
                     }
                 }
                 jsp.service(bindings.getRequest(), bindings.getResponse());

--- a/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
@@ -1,0 +1,136 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package org.apache.sling.scripting.jsp;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+
+import org.apache.sling.api.SlingException;
+import org.apache.sling.api.SlingIOException;
+import org.apache.sling.api.SlingServletException;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.commons.compiler.source.JavaEscapeHelper;
+import org.apache.sling.scripting.bundle.tracker.BundledRenderUnit;
+import org.apache.sling.scripting.jsp.jasper.compiler.JspRuntimeContext;
+import org.apache.sling.scripting.jsp.jasper.runtime.AnnotationProcessor;
+import org.apache.sling.scripting.jsp.jasper.runtime.HttpJspBase;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component(
+        immediate = true,
+        service = {}
+        /*
+         * this component will register itself as a service only if the org.apache.sling.scripting.bundle.tracker API is present
+         */
+        )
+public class PrecompiledJSPRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrecompiledJSPRunner.class);
+
+    private final ServiceRegistration<?> serviceRegistration;
+
+    @Activate
+    public PrecompiledJSPRunner(BundleContext bundleContext) {
+        serviceRegistration = register(bundleContext);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        if (serviceRegistration != null) {
+            serviceRegistration.unregister();
+        }
+    }
+
+    boolean callPrecompiledJSP(JspRuntimeContext.JspFactoryHandler jspFactoryHandler, JspServletConfig jspServletConfig,
+                               SlingBindings bindings) {
+        boolean found = false;
+        BundledRenderUnit bundledRenderUnit = (BundledRenderUnit) bindings.get(BundledRenderUnit.VARIABLE);
+        if (bundledRenderUnit != null && bundledRenderUnit.getUnit() instanceof HttpJspBase) {
+            found = true;
+            HttpJspBase jsp = (HttpJspBase) bundledRenderUnit.getUnit();
+            PrecompiledServletConfig servletConfig = new PrecompiledServletConfig(jspServletConfig, bundledRenderUnit);
+            try {
+                jspFactoryHandler.incUsage();
+                AnnotationProcessor annotationProcessor =
+                        (AnnotationProcessor) jspServletConfig.getServletContext().getAttribute(AnnotationProcessor.class.getName());
+                if (annotationProcessor != null) {
+                    annotationProcessor.processAnnotations(jsp);
+                    annotationProcessor.postConstruct(jsp);
+                }
+                if (jsp.getServletConfig() == null) {
+                    jsp.init(servletConfig);
+                }
+                jsp.service(bindings.getRequest(), bindings.getResponse());
+            } catch (IOException e) {
+                throw new SlingIOException(e);
+            } catch (ServletException e) {
+                throw new SlingServletException(e);
+            } catch (IllegalAccessException | InvocationTargetException | NamingException e) {
+                throw new SlingException("Unable to process annotations for servlet " + servletConfig.getServletName() + ".", e);
+            } finally {
+                jspFactoryHandler.decUsage();
+            }
+        }
+        return found;
+    }
+
+    private ServiceRegistration<?> register(BundleContext bundleContext) {
+        try {
+            PrecompiledJSPRunner.class.getClassLoader().loadClass("org.apache.sling.scripting.bundle.tracker.BundledRenderUnit");
+            return bundleContext.registerService(PrecompiledJSPRunner.class, this, null);
+        } catch (Exception e) {
+            LOGGER.info("No support for precompiled scripts.");
+        }
+        return null;
+    }
+
+    public static class PrecompiledServletConfig extends JspServletConfig {
+
+        private final BundledRenderUnit bundledRenderUnit;
+        private String servletName;
+
+        PrecompiledServletConfig(JspServletConfig jspServletConfig, BundledRenderUnit bundledRenderUnit) {
+            super(jspServletConfig.getServletContext(), new HashMap<>(jspServletConfig.getProperties()));
+            this.bundledRenderUnit = bundledRenderUnit;
+        }
+
+        @Override
+        public String getServletName() {
+            if (servletName == null && bundledRenderUnit.getUnit() != null) {
+                Bundle bundle = bundledRenderUnit.getBundle();
+                Object jsp = bundledRenderUnit.getUnit();
+                String originalName =
+                        JavaEscapeHelper.unescapeAll(jsp.getClass().getPackage().getName()) + "/" + JavaEscapeHelper.unescapeAll(jsp.getClass().getSimpleName());
+                servletName = bundle.getSymbolicName() + ": " + originalName;
+            }
+            return servletName;
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/PrecompiledJSPRunner.java
@@ -36,13 +36,9 @@ import org.apache.sling.scripting.jsp.jasper.runtime.AnnotationProcessor;
 import org.apache.sling.scripting.jsp.jasper.runtime.HttpJspBase;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Component(service = {PrecompiledJSPRunner.class})
 public class PrecompiledJSPRunner {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PrecompiledJSPRunner.class);
 
     boolean callPrecompiledJSP(JspRuntimeContext.JspFactoryHandler jspFactoryHandler, JspServletConfig jspServletConfig,
                                SlingBindings bindings) {

--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/runtime/package-info.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/runtime/package-info.java
@@ -1,0 +1,22 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Licensed to the Apache Software Foundation (ASF) under one
+ ~ or more contributor license agreements.  See the NOTICE file
+ ~ distributed with this work for additional information
+ ~ regarding copyright ownership.  The ASF licenses this file
+ ~ to you under the Apache License, Version 2.0 (the
+ ~ "License"); you may not use this file except in compliance
+ ~ with the License.  You may obtain a copy of the License at
+ ~
+ ~   http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@Version("2.5.0")
+package org.apache.sling.scripting.jsp.jasper.runtime;
+
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/runtime/package-info.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/runtime/package-info.java
@@ -16,6 +16,9 @@
  ~ specific language governing permissions and limitations
  ~ under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+/**
+ * This package should only be used by compiled JSP scripts when being executed on the platform.
+ */
 @Version("2.5.0")
 package org.apache.sling.scripting.jsp.jasper.runtime;
 

--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/servlet/JspServletWrapper.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/servlet/JspServletWrapper.java
@@ -41,7 +41,6 @@ import javax.servlet.jsp.tagext.TagInfo;
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.sling.api.SlingException;
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingIOException;
 import org.apache.sling.api.SlingServletException;
 import org.apache.sling.api.scripting.ScriptEvaluationException;
@@ -442,11 +441,8 @@ public class JspServletWrapper {
      *             request parameter has an illegal value.
      */
     public void service(final SlingBindings bindings) {
-        final SlingHttpServletRequest request = bindings.getRequest();
-        final Object oldValue = request.getAttribute(SlingBindings.class.getName());
         try {
-            request.setAttribute(SlingBindings.class.getName(), bindings);
-            service(request, bindings.getResponse());
+            service(bindings.getRequest(), bindings.getResponse());
         } catch (SlingException se) {
             // rethrow as is
             throw se;
@@ -454,8 +450,6 @@ public class JspServletWrapper {
             throw new SlingIOException(ioe);
         } catch (ServletException se) {
             throw new SlingServletException(se);
-        } finally {
-            request.setAttribute(SlingBindings.class.getName(), oldValue);
         }
     }
 


### PR DESCRIPTION
* added an optional import for `org.apache.sling.scripting.bundle.tracker`
* added the `PrecompiledJSPRunner` which registers itself as a service if the previous API is available
* if the `PrecompiledJSPRunner` is available, the `JSPScriptEngine` will try to execute a precompiled JSP, if one was available in the script context, otherwise it will try to compile the script matching the request