### PR TITLE
SLING-10399 - Enhance the compilation report provided by the jspc-maven-plugin

### DIFF
--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/JspCompilationContext.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/JspCompilationContext.java
@@ -495,10 +495,14 @@ public class JspCompilationContext {
     // ==================== Compile and reload ====================
 
     public JasperException compile() {
+        return compile(false);
+    }
+
+    public JasperException compile(boolean fromJSPC) {
         final Compiler c = createCompiler();
         try {
             c.removeGeneratedFiles();
-            c.compile();
+            c.compile(true, fromJSPC);
         } catch (final JasperException ex) {
             return ex;
         } catch (final IOException ioe) {
@@ -508,11 +512,11 @@ public class JspCompilationContext {
             return je;
         } catch (final Exception ex) {
             JasperException je = new JasperException(
-                        Localizer.getMessage("jsp.error.unable.compile"),
-                        ex);
+                    Localizer.getMessage("jsp.error.unable.compile"),
+                    ex);
             return je;
         } finally {
-           c.clean();
+            c.clean();
         }
 
         return null;

--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/compiler/Compiler.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/compiler/Compiler.java
@@ -313,7 +313,9 @@ public abstract class Compiler {
             // memory footprint.
             tfp = null;
             errDispatcher = null;
-            pageInfo = null;
+            if (!jspcMode) {
+                pageInfo = null;
+            }
 
             // Only get rid of the pageNodes if in production.
             // In development mode, they are used for detailed

--- a/src/main/java/org/apache/sling/scripting/jsp/jasper/compiler/PageInfo.java
+++ b/src/main/java/org/apache/sling/scripting/jsp/jasper/compiler/PageInfo.java
@@ -36,7 +36,7 @@ import javax.servlet.jsp.tagext.TagLibraryInfo;
  * @author Kin-man Chung
  */
 
-class PageInfo {
+public class PageInfo {
 
     private Vector imports;
     private Vector dependants;


### PR DESCRIPTION
* expose `o.a.s.scripting.jsp.jasper.compiler.PageInfo`
* keep the `PageInfo` object in the `Compiler` when running from `jspc`